### PR TITLE
本地漫画详情入口/下载链路修复 + web 阅读历史刷新

### DIFF
--- a/lib/foundation/local_native.dart
+++ b/lib/foundation/local_native.dart
@@ -741,20 +741,35 @@ class LocalManager with ChangeNotifier {
     }
   }
 
-  /// Deletes the directories in a separate isolate to avoid blocking the UI thread.
+  /// Deletes the directories without blocking the UI thread.
+  ///
+  /// On Android the file paths may be SAF (android://) URIs that can only be
+  /// resolved through [SAFTaskWorker], so deletion runs in a dedicated isolate
+  /// that initializes the worker. On other platforms the paths are plain file
+  /// system paths, so we delete them directly with async I/O — spawning a SAF
+  /// isolate there is unnecessary and, because the worker's receive port is
+  /// never closed, leaks an isolate on every delete (and could hang on
+  /// platforms without the SAF channel).
   static void _deleteDirectories(List<Directory> directories) {
-    Isolate.run(() async {
-      await SAFTaskWorker().init();
-      for (var dir in directories) {
-        try {
-          if (dir.existsSync()) {
-            await dir.delete(recursive: true);
+    if (directories.isEmpty) return;
+    if (App.isAndroid) {
+      Isolate.run(() async {
+        await SAFTaskWorker().init();
+        for (var dir in directories) {
+          try {
+            if (dir.existsSync()) {
+              await dir.delete(recursive: true);
+            }
+          } catch (e) {
+            continue;
           }
-        } catch (e) {
-          continue;
         }
+      });
+    } else {
+      for (var dir in directories) {
+        dir.deleteIgnoreError(recursive: true);
       }
-    });
+    }
   }
 
   static String getChapterDirectoryName(String name) {

--- a/lib/network/download_native.dart
+++ b/lib/network/download_native.dart
@@ -330,8 +330,13 @@ class ImagesDownloadTask extends DownloadTask with _TransferSpeedMixin {
     }
 
     if (_images == null) {
-      if (comic!.chapters == null && chapters != null) {
-        // Multi-chapter comic but chapters data lost during restore
+      if (comic!.chapters == null && source.loadComicInfo != null) {
+        // Chapter info may be missing because the task was created from a
+        // local-first placeholder (network details not yet resolved) or lost
+        // during restore. Fetch authoritative details before deciding whether
+        // this is a single- or multi-chapter comic, otherwise a multi-chapter
+        // comic would download `chapter/null`. A genuinely single-chapter
+        // comic keeps `chapters == null` and falls through to the path below.
         _message = "Fetching comic info...".tl;
         notifyListeners();
         var res = await _runWithRetry(() async {
@@ -598,16 +603,17 @@ class ImagesDownloadTask extends DownloadTask with _TransferSpeedMixin {
   @override
   LocalComic toLocalComic() {
     return LocalComic(
-      id: comic!.id,
+      id: id,
       title: title,
-      subtitle: comic!.subTitle ?? '',
-      tags: comic!.tags.entries.expand((e) {
-        return e.value.map((v) => "${e.key}:$v");
-      }).toList(),
-      directory: Directory(path!).name,
-      chapters: comic!.chapters,
-      cover: File(_cover!.split("file://").last).name,
-      comicType: ComicType(source.key.hashCode),
+      subtitle: comic?.subTitle ?? '',
+      tags: comic?.tags.entries.expand((e) {
+            return e.value.map((v) => "${e.key}:$v");
+          }).toList() ??
+          [],
+      directory: path == null ? '' : Directory(path!).name,
+      chapters: comic?.chapters,
+      cover: _cover == null ? '' : File(_cover!.split("file://").last).name,
+      comicType: comicType,
       downloadedChapters: chapters ?? comic?.chapters?.ids.toList() ?? [],
       createdAt: DateTime.now(),
     );

--- a/lib/pages/comic_details_page/actions.dart
+++ b/lib/pages/comic_details_page/actions.dart
@@ -275,18 +275,30 @@ abstract mixin class _ComicPageActions {
       }
     }
 
-    if (comic.chapters == null) {
+    // The comic details may be a local-first placeholder whose chapter info
+    // hasn't been resolved yet (background network fetch still pending or
+    // failed). In that case a multi-chapter comic looks single-chapter and
+    // would download `chapter/null`. Resolve authoritative details first.
+    var details = comic;
+    if (details.chapters == null && source.loadComicInfo != null) {
+      var res = await source.loadComicInfo!(comic.id);
+      if (res.success && res.data.chapters != null) {
+        details = res.data;
+      }
+    }
+
+    if (details.chapters == null) {
       LocalManager().addTask(
-        ImagesDownloadTask(source: source, comicId: comic.id, comic: comic),
+        ImagesDownloadTask(source: source, comicId: comic.id, comic: details),
       );
     } else {
       List<int>? selected;
       var downloaded = <int>[];
       var localComic = LocalManager().find(comic.id, comic.comicType);
       if (localComic != null) {
-        for (int i = 0; i < comic.chapters!.length; i++) {
+        for (int i = 0; i < details.chapters!.length; i++) {
           if (localComic.downloadedChapters.contains(
-            comic.chapters!.ids.elementAt(i),
+            details.chapters!.ids.elementAt(i),
           )) {
             downloaded.add(i);
           }
@@ -295,7 +307,7 @@ abstract mixin class _ComicPageActions {
       await showSideBar(
         App.rootContext,
         _SelectDownloadChapter(
-          comic.chapters!.titles.toList(),
+          details.chapters!.titles.toList(),
           (v) => selected = v,
           downloaded,
         ),
@@ -305,9 +317,9 @@ abstract mixin class _ComicPageActions {
         ImagesDownloadTask(
           source: source,
           comicId: comic.id,
-          comic: comic,
+          comic: details,
           chapters: selected!.map((i) {
-            return comic.chapters!.ids.elementAt(i);
+            return details.chapters!.ids.elementAt(i);
           }).toList(),
         ),
       );

--- a/lib/pages/comic_details_page/comic_page.dart
+++ b/lib/pages/comic_details_page/comic_page.dart
@@ -179,8 +179,6 @@ class _ComicPageState extends LoadingState<ComicPage, ComicDetails>
     }
   }
 
-  var isFirst = true;
-
   @override
   Widget buildContent(BuildContext context, ComicDetails data) {
     return Scaffold(
@@ -218,39 +216,32 @@ class _ComicPageState extends LoadingState<ComicPage, ComicDetails>
 
   @override
   Future<Res<ComicDetails>> loadData() async {
-    if (widget.sourceKey == 'local') {
-      var state = _comicStateRepository.load(widget.sourceKey, widget.id);
-      var localComic = state.localComic;
-      if (localComic == null) {
-        return const Res.error('Local comic not found');
-      }
-      _comicStateRepository.mirrorLocalComic(localComic);
-      if (isFirst) {
-        Future.microtask(() {
-          App.rootContext.to(() {
-            return Reader(
-              type: ComicType.local,
-              cid: widget.id,
-              name: localComic.title,
-              chapters: localComic.chapters,
-              initialPage: state.history?.page,
-              initialChapter: state.history?.ep,
-              initialChapterGroup: state.history?.group,
-              history:
-                  state.history ??
-                  History.fromModel(model: localComic, ep: 0, page: 0),
-              author: localComic.subTitle ?? '',
-              tags: localComic.tags,
-            );
-          });
-          App.mainNavigatorKey!.currentContext!.pop();
-        });
-        isFirst = false;
-      }
-      await Future.delayed(const Duration(milliseconds: 200));
-      return const Res.error('Local comic');
-    }
     var state = _comicStateRepository.load(widget.sourceKey, widget.id);
+    var localComic = state.localComic;
+
+    // Local-first: if the comic is already in the local library (whether a
+    // purely local import or downloaded from a source), show its details
+    // immediately so it opens instantly and can be read offline. The network
+    // fetch (if a source is available) still runs in the background to enrich
+    // comments/recommendations.
+    if (localComic != null) {
+      _comicStateRepository.mirrorLocalComic(localComic);
+      isAddToLocalFav = state.isLocalFavorite;
+      history = state.history;
+      isDownloaded = true;
+      detailsLoadError = null;
+      var comicSource = ComicSource.find(widget.sourceKey);
+      if (comicSource != null && comicSource.loadComicInfo != null) {
+        _networkFetching = true;
+        scheduleMicrotask(() => _fetchNetworkDetails(comicSource));
+      }
+      return Res(_localDetails(localComic, state));
+    }
+
+    if (widget.sourceKey == 'local') {
+      return const Res.error('Local comic not found');
+    }
+
     isAddToLocalFav = state.isLocalFavorite;
     history = state.history;
     detailsLoadError = null;
@@ -263,6 +254,40 @@ class _ComicPageState extends LoadingState<ComicPage, ComicDetails>
     _networkFetching = true;
     scheduleMicrotask(() => _fetchNetworkDetails(comicSource));
     return Res(_fallbackDetails(state));
+  }
+
+  ComicDetails _localDetails(LocalComic localComic, ComicState state) {
+    var tagsMap = <String, List<String>>{};
+    for (var tag in localComic.tags) {
+      var parts = tag.split(':');
+      var key = parts.length > 1 ? parts.first : 'Tags';
+      var value = parts.length > 1 ? parts.sublist(1).join(':') : tag;
+      tagsMap.putIfAbsent(key, () => []).add(value);
+    }
+    return ComicDetails.fromJson({
+      'title': localComic.title,
+      'subtitle': localComic.subtitle,
+      'cover': localComic.cover,
+      'description': localComic.description,
+      'tags': tagsMap,
+      'chapters': localComic.chapters?.toJson(),
+      'sourceKey': widget.sourceKey,
+      'comicId': widget.id,
+      'thumbnails': null,
+      'recommend': null,
+      'isFavorite': state.isLocalFavorite,
+      'subId': null,
+      'likesCount': null,
+      'isLiked': null,
+      'commentCount': null,
+      'uploader': null,
+      'uploadTime': null,
+      'updateTime': null,
+      'url': null,
+      'stars': null,
+      'maxPage': null,
+      'comments': null,
+    });
   }
 
   Future<void> _fetchNetworkDetails(ComicSource source) async {

--- a/lib/pages/local_comics_page.dart
+++ b/lib/pages/local_comics_page.dart
@@ -417,7 +417,13 @@ class _LocalComicsPageState extends State<LocalComicsPage>
                 if (comic.status == LocalComicStatus.notDownloaded) {
                   _showNotDownloadedDialog(comic);
                 } else {
-                  comic.read();
+                  // Unified entry: open the comic detail page (same as online
+                  // comics). The detail page loads local data first so it opens
+                  // instantly and can be read offline.
+                  context.to(() => ComicPage(
+                        id: comic.id,
+                        sourceKey: comic.sourceKey,
+                      ));
                 }
               }
             },

--- a/web/client/src/pages/comic/ComicDetailPage.vue
+++ b/web/client/src/pages/comic/ComicDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, onActivated } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { apiPost } from '@/services/api'
 import { addFavorite, deleteFavorite, getComicSources, listFavorites, listFolders, listHistory, createFolder, markAsRead } from '@/services/server-db'
@@ -83,37 +83,44 @@ const flatChapters = computed<Chapter[]>(() => {
   if (isGrouped.value) return (chapters.value as ChapterGroup[]).flatMap(g => g.chapters)
   return chapters.value as Chapter[]
 })
-const lastReadInfo = computed(() => {
-  if (!lastReadChapterId.value) return null
-  const id = lastReadChapterId.value
-  // Try matching by chapter ID first
+// Resolve the stored last-read chapter id (which may be an actual chapter id,
+// a "groupIdx-chapterIdx" positional pair, or a 1-based flat index) to the
+// real Chapter object. Returns the chapter plus the resolved group index.
+function resolveHistoryChapter(id: string): { chapter: Chapter | undefined; groupIdx: number | null } {
   let ch = flatChapters.value.find(c => c.id === id)
-  let resolvedGroupIdx: number | null = null
-  if (!ch) {
-    // Check if it's a "groupIdx-chapterIdx" positional format (for grouped chapters)
-    const dashIdx = id.indexOf('-')
-    if (dashIdx > 0) {
-      const gIdx = parseInt(id.substring(0, dashIdx), 10)
-      const cIdx = parseInt(id.substring(dashIdx + 1), 10)
-      if (!isNaN(gIdx) && !isNaN(cIdx) && isGrouped.value) {
-        const groups = chapters.value as ChapterGroup[]
-        if (gIdx >= 1 && gIdx <= groups.length) {
-          const group = groups[gIdx - 1]
-          if (group?.chapters && cIdx >= 1 && cIdx <= group.chapters.length) {
-            ch = group.chapters[cIdx - 1]
-            resolvedGroupIdx = gIdx
-          }
+  if (ch) return { chapter: ch, groupIdx: null }
+  // "groupIdx-chapterIdx" positional format (for grouped chapters), both 1-based
+  const dashIdx = id.indexOf('-')
+  if (dashIdx > 0) {
+    const gIdx = parseInt(id.substring(0, dashIdx), 10)
+    const cIdx = parseInt(id.substring(dashIdx + 1), 10)
+    if (!isNaN(gIdx) && !isNaN(cIdx) && isGrouped.value) {
+      const groups = chapters.value as ChapterGroup[]
+      if (gIdx >= 1 && gIdx <= groups.length) {
+        const group = groups[gIdx - 1]
+        if (group?.chapters && cIdx >= 1 && cIdx <= group.chapters.length) {
+          return { chapter: group.chapters[cIdx - 1], groupIdx: gIdx }
         }
       }
     }
-    // Fallback: try as a simple 1-based flat index
-    if (!ch) {
-      const idx = parseInt(id, 10)
-      if (!isNaN(idx) && idx >= 1 && idx <= flatChapters.value.length) {
-        ch = flatChapters.value[idx - 1]
-      }
-    }
   }
+  // Fallback: simple 1-based flat index
+  const idx = parseInt(id, 10)
+  if (!isNaN(idx) && idx >= 1 && idx <= flatChapters.value.length) {
+    return { chapter: flatChapters.value[idx - 1], groupIdx: null }
+  }
+  return { chapter: undefined, groupIdx: null }
+}
+
+const lastReadChapter = computed<Chapter | undefined>(() => {
+  if (!lastReadChapterId.value) return undefined
+  return resolveHistoryChapter(lastReadChapterId.value).chapter
+})
+
+const lastReadInfo = computed(() => {
+  if (!lastReadChapterId.value) return null
+  const id = lastReadChapterId.value
+  const { chapter: ch, groupIdx: resolvedGroupIdx } = resolveHistoryChapter(id)
   const groupIdxForDisplay = resolvedGroupIdx ?? lastReadGroup.value ?? 0
   const groupName = groupTitles.value[groupIdxForDisplay > 0 ? groupIdxForDisplay - 1 : 0] || groupTitles.value[lastReadGroup.value ?? 0] || '默認'
   return { group: groupName, chapter: ch?.title || id, page: lastReadPage.value }
@@ -126,7 +133,7 @@ const sourceDisplayName = computed(() => {
   return detailSourceName.value || source?.sourceName || source?.displayName || source?.name || sourceKey.value
 })
 
-const hasHistory = computed(() => lastReadChapterId.value != null && lastReadPage.value > 1)
+const hasHistory = computed(() => lastReadChapterId.value != null)
 const parsedTags = computed(() => comic.value ? parseComicTags(comic.value as any) : { authors: [] as string[], statuses: [] as string[], updates: [] as string[], contentTags: [] as string[] })
 const displayAuthors = computed(() => {
   const fromSubtitle = comic.value?.subtitle || (comic.value as any)?.author || ''
@@ -531,7 +538,13 @@ function readComic(chapter?: Chapter) {
     showToast('暂无可阅读章节')
     return
   }
-  const page = (ch.id === lastReadChapterId.value) ? lastReadPage.value : 1
+  // Resume the saved page only when opening the chapter that was last read.
+  // lastReadChapterId may be stored as a positional id, so compare against the
+  // resolved chapter object rather than the raw id.
+  const isLastRead = lastReadChapter.value
+    ? ch.id === lastReadChapter.value.id
+    : ch.id === lastReadChapterId.value
+  const page = isLastRead ? lastReadPage.value : 1
   router.push({
     path: `/reader/${sourceKey.value}/${comicId.value}`,
     query: { ep: ch.id, page: String(page) },
@@ -539,36 +552,8 @@ function readComic(chapter?: Chapter) {
 }
 
 function continueReading() {
-  if (lastReadChapterId.value) {
-    const id = lastReadChapterId.value
-    // Try matching by chapter ID first
-    let ch = flatChapters.value.find(c => c.id === id)
-    if (!ch) {
-      // Check if it's a "groupIdx-chapterIdx" positional format (for grouped chapters)
-      const dashIdx = id.indexOf('-')
-      if (dashIdx > 0) {
-        const gIdx = parseInt(id.substring(0, dashIdx), 10)
-        const cIdx = parseInt(id.substring(dashIdx + 1), 10)
-        if (!isNaN(gIdx) && !isNaN(cIdx) && isGrouped.value) {
-          const groups = chapters.value as ChapterGroup[]
-          if (gIdx >= 1 && gIdx <= groups.length) {
-            const group = groups[gIdx - 1]
-            if (group?.chapters && cIdx >= 1 && cIdx <= group.chapters.length) {
-              ch = group.chapters[cIdx - 1]
-            }
-          }
-        }
-      }
-      // Fallback: try as a simple 1-based flat index
-      if (!ch) {
-        const idx = parseInt(id, 10)
-        if (!isNaN(idx) && idx >= 1 && idx <= flatChapters.value.length) {
-          ch = flatChapters.value[idx - 1]
-        }
-      }
-    }
-    if (ch) { readComic(ch); return }
-  }
+  const ch = lastReadChapter.value
+  if (ch) { readComic(ch); return }
   readComic()
 }
 
@@ -663,6 +648,13 @@ onMounted(async () => {
   } else {
     setTimeout(loadOptional, 300)
   }
+})
+
+onActivated(() => {
+  // Page is kept-alive; when navigating back from the reader, onMounted does
+  // not run again. Re-fetch reading progress so the chapter list "read" styles
+  // and the 上次阅读 / 继续 button reflect the latest history.
+  void fetchHistory()
 })
 
 onUnmounted(() => {
@@ -906,8 +898,8 @@ onUnmounted(() => {
             :key="ch.id"
             class="chapter-btn"
             :class="{
-              'is-current': ch.id === lastReadChapterId,
-              'is-read': isChapterRead(ch.id) && ch.id !== lastReadChapterId
+              'is-current': ch.id === (lastReadChapter?.id ?? lastReadChapterId),
+              'is-read': isChapterRead(ch.id) && ch.id !== (lastReadChapter?.id ?? lastReadChapterId)
             }"
             @click="readComic(ch)"
           >

--- a/web/client/src/pages/home/HomePage.vue
+++ b/web/client/src/pages/home/HomePage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from 'vue'
+import { ref, computed, onMounted, onUnmounted, onActivated } from 'vue'
 import { useRouter } from 'vue-router'
 import ProxiedImage from '@/components/ProxiedImage.vue'
 import { listHistory, getComicSources, listFavorites, clearComicSourcesCache } from '@/services/server-db'
@@ -64,16 +64,27 @@ async function refreshSyncStatus() {
 }
 
 let visibilityHandler: (() => void) | null = null
+let activatedOnce = false
 
 onMounted(async () => {
   await syncStore.bootstrapAutoDownload()
   await settingsStore.loadSettings()
   await refreshHomeData()
+  activatedOnce = true
 
   visibilityHandler = () => {
     if (document.visibilityState === 'visible') refreshHomeData()
   }
   document.addEventListener('visibilitychange', visibilityHandler)
+})
+
+onActivated(() => {
+  // Kept-alive: onActivated also fires right after the first onMounted, so skip
+  // that one (onMounted already loaded). On later activations (e.g. returning
+  // from a comic detail page after reading), refresh so the history list shows
+  // the most recently read comic at the front.
+  if (!activatedOnce) return
+  void refreshHomeData()
 })
 
 onUnmounted(() => {


### PR DESCRIPTION
## 概述
本地漫画体验与下载链路修复，附带 web PWA 阅读历史刷新修复。

## 变更
**feat(local): 本地漫画统一详情页入口并本地优先加载**
- 本地漫画统一走详情页入口，优先加载本地数据

**fix(download): 修复本地漫画下载链路两处问题**
- 修复本地漫画下载链路的两处缺陷

**fix(web): 阅读历史在 keep-alive 页面返回后正确刷新**
- 详情页/主页改用 onActivated 返回时重新拉取历史，章节"已读/当前"样式与"继续阅读"按钮反映最新进度
- 抽取 resolveHistoryChapter 统一解析历史章节 id
- hasHistory 不再要求 page>1

## 测试
- `flutter analyze` 改动文件无 issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)