### PR TITLE
fix(android): handle external comic links (issue #72)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,6 +39,65 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
+            <!-- Issue #72: open comic links in the app.
+                 Custom scheme (venerax://open?url=<encoded> or venerax://<host>/<path>)
+                 plus the fixed comic-site domains declared by built-in sources.
+                 One intent-filter per host: multiple <data> inside a single filter
+                 are AND-ed, so they must stay separate to match each domain. -->
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="venerax" />
+            </intent-filter>
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="nhentai.net" />
+            </intent-filter>
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="e-hentai.org" />
+            </intent-filter>
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="exhentai.org" />
+            </intent-filter>
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="h-comic.com" />
+            </intent-filter>
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="hitomi.la" />
+            </intent-filter>
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="jcomic.net" />
+            </intent-filter>
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="mangadex.org" />
+            </intent-filter>
+            <intent-filter android:label="Open in VeneraX">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="mycomic.com" />
+            </intent-filter>
         </activity>
         <!-- Launcher icon presets. One alias enabled at a time; plugin applies
              the switch on onTaskRemoved (takes effect next cold start). Default

--- a/lib/utils/app_links.dart
+++ b/lib/utils/app_links.dart
@@ -1,32 +1,82 @@
+﻿import 'dart:async';
 import 'package:app_links/app_links.dart';
 import 'package:venera/foundation/app.dart';
 import 'package:venera/foundation/comic_source/comic_source.dart';
 import 'package:venera/pages/comic_details_page/comic_page.dart';
 
+/// Registers the app as a handler for comic links (issue #72).
+///
+/// Covers both entry paths:
+/// - cold start: the app is launched by an external link (getInitialLink)
+/// - warm start: the app is already running (uriLinkStream)
 void handleLinks() {
   final appLinks = AppLinks();
+  appLinks.getInitialLink().then((uri) {
+    if (uri != null) {
+      handleAppLink(uri);
+    }
+  });
   appLinks.uriLinkStream.listen((uri) {
     handleAppLink(uri);
   });
 }
 
+/// Resolves an external link to a comic and opens its detail page.
+///
+/// Accepted link forms:
+/// - `https://<domain>/...` where <domain> is declared by a source's
+///   `comic.link.domains` (e.g. nhentai.net/g/123456)
+/// - `venerax://open?url=<urlencoded>` carrying a full comic url
+/// - `venerax://<host>/<path>` shorthand that maps back to https
 Future<bool> handleAppLink(Uri uri) async {
-  for(var source in ComicSource.all()) {
-    if(source.linkHandler != null) {
-      if(source.linkHandler!.domains.contains(uri.host)) {
-        var id = source.linkHandler!.linkToId(uri.toString());
-        if(id != null) {
-          if(App.mainNavigatorKey == null) {
-            await Future.delayed(const Duration(milliseconds: 200));
-          }
-          App.mainNavigatorKey!.currentContext?.to(() {
-            return ComicPage(id: id, sourceKey: source.key);
-          });
-          return true;
-        }
-        return false;
-      }
+  var target = uri;
+
+  // Unwrap the custom scheme into a regular https url.
+  if (target.scheme == 'venerax') {
+    if (target.host == 'open') {
+      final encoded = target.queryParameters['url'];
+      if (encoded == null) return false;
+      target = Uri.parse(encoded);
+    } else {
+      target = Uri(
+        scheme: 'https',
+        host: target.host,
+        port: target.hasPort ? target.port : null,
+        path: target.path,
+        query: target.query,
+      );
     }
+  }
+
+  if (target.scheme != 'https' && target.scheme != 'http') return false;
+
+  // On a cold start the sources may not be registered yet; wait for them
+  // (they are loaded during app init, but the initial link can arrive first).
+  var attempts = 0;
+  while (ComicSource.all().isEmpty && attempts < 50) {
+    await Future.delayed(const Duration(milliseconds: 100));
+    attempts++;
+  }
+  if (ComicSource.all().isEmpty) return false;
+
+  final host = target.host.replaceFirst(RegExp(r'^www\.'), '');
+
+  for (final source in ComicSource.all()) {
+    final handler = source.linkHandler;
+    if (handler == null || !handler.domains.contains(host)) continue;
+    final id = handler.linkToId(target.toString());
+    if (id == null || id.isEmpty) return false;
+
+    // The navigator is set once the UI is up; wait briefly if needed.
+    attempts = 0;
+    while (App.mainNavigatorKey?.currentContext == null && attempts < 50) {
+      await Future.delayed(const Duration(milliseconds: 100));
+      attempts++;
+    }
+    App.mainNavigatorKey?.currentContext?.to(() {
+      return ComicPage(id: id, sourceKey: source.key);
+    });
+    return true;
   }
   return false;
 }


### PR DESCRIPTION
Fixes #72

- Register VIEW intent-filters for the custom venerax:// scheme and the fixed comic-site domains declared by built-in sources
- Handle cold start links via AppLinks.getInitialLink (previously only the warm-start uriLinkStream was listened to)
- Support venerax://open?url=<encoded> and venerax://<host>/<path>
- Wait for comic sources / navigator to be ready before navigating and strip a leading www. from the host for more lenient matching