### PR TITLE
chore(deps): ignore sqlite EOL marker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # Version 0.6.0+eol is an empty marker for sqlite3 3.x migrations.
+      - dependency-name: "sqlite3_flutter_libs"
+        versions:
+          - ">=0.6.0"
       # Keep the Xcode 16.4 compatibility pin documented in pubspec.yaml.
       - dependency-name: "connectivity_plus"
         update-types:


### PR DESCRIPTION
## Summary

- keep Dependabot from updating sqlite3_flutter_libs to the empty 0.6.x EOL marker
- preserve the native SQLite bundle while the app remains on sqlite3 2.x

## Verification

- Dependabot YAML parsed successfully
- git diff --check passed

The ignored version can be removed during a coordinated migration to sqlite3 3.x.