### PR TITLE
chore(deps): pin native HTTP toolchain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
       - dependency-name: "sqlite3_flutter_libs"
         versions:
           - ">=0.6.0"
+      # Keep the native HTTP stack on its tested bridge and Rust toolchain pair.
+      - dependency-name: "rhttp"
+        versions:
+          - ">=0.16.0"
+      - dependency-name: "flutter_rust_bridge"
+        versions:
+          - ">=2.12.0"
       # Keep the Xcode 16.4 compatibility pin documented in pubspec.yaml.
       - dependency-name: "connectivity_plus"
         update-types:


### PR DESCRIPTION
## Summary

- keep rhttp on 0.15.1
- keep flutter_rust_bridge on the matching 2.11.1 runtime
- prevent Dependabot from recreating a cross-platform build failure

## Evidence

rhttp 0.18.0 pins Rust 1.85.1, but its resolved cookie_store, ICU, IDNA, and time crates require Rust 1.86 through 1.88. Android, iOS, macOS, and Linux x64 failed in Build ALL run 32818657028.

## Verification

- Dependabot YAML parsed successfully
- git diff --check passed