### PR TITLE
chore(deps): pin syntax highlighter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,10 @@ updates:
       - dependency-name: "flutter_rust_bridge"
         versions:
           - ">=2.12.0"
+      # Version 0.5.x adds a second Cargokit plugin that races rhttp's rustup setup.
+      - dependency-name: "syntax_highlight"
+        versions:
+          - ">=0.5.0"
       # Keep the Xcode 16.4 compatibility pin documented in pubspec.yaml.
       - dependency-name: "connectivity_plus"
         update-types:


### PR DESCRIPTION
## Summary

- keep syntax_highlight on 0.4.0
- prevent super_clipboard and a second Cargokit plugin from entering the build
- avoid concurrent rustup toolchain and target setup with rhttp

## Evidence

Build ALL run 32820988507 reproduced iOS rustup target installation races and Linux toolchain failures after syntax_highlight 0.5.0 introduced super_native_extensions.

## Verification

- dependency graph traced with flutter pub deps
- Dependabot YAML parsed successfully
- git diff --check passed