### PR TITLE
fix(reader): update continuous mode viewport on orientation change

### DIFF
--- a/lib/pages/reader/images.dart
+++ b/lib/pages/reader/images.dart
@@ -1818,8 +1818,9 @@ class _ContinuousModeState extends State<_ContinuousMode>
       },
       child: widget,
     );
-    var width = reader.size.width;
-    var height = reader.size.height;
+    final viewportSize = MediaQuery.sizeOf(context);
+    var width = viewportSize.width;
+    var height = viewportSize.height;
     // The ratio drives both the trigger and the cap: comparing against a fixed
     // 0.7 while capping at a larger ratio would widen the image past the
     // viewport it was meant to narrow.


### PR DESCRIPTION
## Summary

Fix an issue in continuous reading mode that occurs when rotating from portrait to landscape and then back to portrait. After returning to portrait orientation, the reader could continue using the previous viewport size, causing the layout to be incorrect.

## Changes

Use `MediaQuery.sizeOf(context)` for the image display size instead of `reader.size`.

## Testing

Tested on a physical Android device in continuous reading mode. Before this change, rotating from portrait to landscape and then back to portrait could leave the reader using the previous viewport size, resulting in an incorrect layout (Figure 1). After the change, the reader correctly updates to the current viewport size when returning to portrait orientation (Figure 2).
<img width="1440" height="3200" alt="Screenshot_2026-08-29-21-21-12-579_io github kyo" src="https://github.com/user-attachments/assets/ccbb92da-8ad4-44d9-8373-f4173d7a09d0" />
<img width="1440" height="3200" alt="Screenshot_2026-08-29-21-25-09-857_io github kyo" src="https://github.com/user-attachments/assets/9d6ad01d-3a47-4c04-96ef-4217f0f6c034" />
